### PR TITLE
Support SQL operators in query params

### DIFF
--- a/services/clients/storage.js
+++ b/services/clients/storage.js
@@ -1,9 +1,10 @@
+const { getWhereConditions } = require(`${process.env['FILE_ENVIRONMENT']}/globals/common`)
+
 const findAllBy = (fields = {}, debug) => {
-  const whereFields = Object.keys(fields).flatMap(k => (fields[k] ? `${k} = '${fields[k]}'` : []))
   const query = `
     SELECT id, name, nit, address, phone, alternative_phone, business_man, payments_man
     FROM clients
-    WHERE is_active = 1 ${whereFields.length > 0 ? 'AND' : ''} ${whereFields.join(' AND ')}
+    WHERE is_active = 1 ${getWhereConditions(fields)}
   `
   if (debug) console.log(query)
   return query


### PR DESCRIPTION
## Pull Request Description
- [x] QA @userlab-luismoreno 
- [ ] CR @userlab-cesarsalazar 

## What changed?
- Se agrego soporte para enviar operadores con los query params
- Los operadores soportados son los siguientes (queryParam , sql):
    $eq: , '='
    $ne: , '!='
    $gt: , '>'
    $gte: , '>='
    $lt: , '<'
    $lte: , '<='
    $like: , 'LIKE'
    $notlike: , 'NOT LIKE'
    $or: , 'OR'
- La sintaxis de los operadores es la siguiente $< nombre del operador >:
- Los operadores se deben pasar como prefijo en el valor del query param. Ej: ?name=$like:luis%
- Solo se soporta un parametro en cada query param, a excepcion del "$or" que puede ir acompañado por otro operador. Ej: $like$or:

## Test plan
GET - clients
https://www.getpostman.com/collections/bf99a61771f594d14032