### PR TITLE
Avoid inventory movements for services

### DIFF
--- a/globals/helpers/handleCreateInventoryMovements.js
+++ b/globals/helpers/handleCreateInventoryMovements.js
@@ -1,5 +1,23 @@
 const types = require('../types')
 
+// req.body: {
+//   document_type,
+//   operation_id,
+//   products: [
+//     {
+//       product_id,
+//       product_type,
+//       stock,
+//       product_price,
+//       tax_fee,
+//       product_quantity,
+//       product_discount_percentage,
+//       product_discount,
+//       unit_tax_amount,
+//     },
+//   ],
+// }
+
 const handleCreateInventoryMovements = async (req, res) => {
   // if both are needed, keep the order in the next array, first 'OUT' then 'IN'
   // [inventoryMovementsTypes.OUT, inventoryMovementsTypes.IN],
@@ -17,7 +35,9 @@ const handleCreateInventoryMovements = async (req, res) => {
   const movementTypes = config[document_type]
 
   const inventoryMovements = movementTypes.reduce((movementsResult, movement_type) => {
-    const movements = products.map(p => {
+    const movements = products.flatMap(p => {
+      if (p.product_type === types.productsTypes.SERVICE) return []
+
       const unit_cost = movement_type === types.inventoryMovementsTypes.IN ? p.product_price : null
 
       return { operation_id, product_id: p.product_id, quantity: p.product_quantity, unit_cost, movement_type }

--- a/globals/helpers/handleRead.js
+++ b/globals/helpers/handleRead.js
@@ -28,7 +28,7 @@ const addReadEnum =
 const addGroupJoinResult =
   fn =>
   async (req, { nestedFieldsKeys, uniqueKey, data, ...res }) => {
-    const groupedData = groupJoinResult({ data: data, nestedFieldsKeys, uniqueKey })
+    const groupedData = nestedFieldsKeys ? groupJoinResult({ data, nestedFieldsKeys, uniqueKey }) : data
 
     return await fn(req, { ...res, nestedFieldsKeys, uniqueKey, statusCode: 200, data: groupedData })
   }

--- a/services/invoices/storage.js
+++ b/services/invoices/storage.js
@@ -60,6 +60,7 @@ const findStakeholder = (fields = {}, initWhereCondition = `status = '${types.st
 const findProducts = whereIn => `
   SELECT
     p.id AS product_id,
+    p.product_type,
     p.stock,
     p.unit_price AS product_price,
     t.fee AS tax_fee

--- a/services/purchases/storage.js
+++ b/services/purchases/storage.js
@@ -45,6 +45,7 @@ const findStakeholder = (fields = {}, initWhereCondition = `status = '${types.st
 const findProducts = whereIn => `
   SELECT
     p.id AS product_id,
+    p.product_type,
     p.stock,
     p.unit_price AS product_price,
     t.fee AS tax_fee

--- a/services/sales/storage.js
+++ b/services/sales/storage.js
@@ -69,6 +69,7 @@ const findStakeholder = (fields = {}, initWhereCondition = `status = '${types.st
 const findProducts = whereIn => `
   SELECT
     p.id AS product_id,
+    p.product_type,
     p.stock,
     p.unit_price AS product_price,
     t.fee AS tax_fee
@@ -136,6 +137,7 @@ const findDocumentDetails = () => `
     dp.product_price AS products__product_price,
     dp.tax_fee AS products__tax_fee,
     dp.unit_tax_amount AS products__unit_tax_amount,
+    p.product_type AS products__product_type,
     p.status AS products__product_status,
     p.stock AS products__product_stock
   FROM documents d


### PR DESCRIPTION
## Pull Request Description
- [x] QA @userlab-luismoreno 
- [ ] CR @userlab-cesarsalazar @userlab-luisdeleon 

## What changed?
- Se agrego un guard para evitar registrar movimientos de inventario cuando el product_type sea igual a "SERVICE", y asi evitar problemas de stock con ese tipo de productos

## Test plan
N/A